### PR TITLE
Ensure RAG loaders validate paths and expose metadata

### DIFF
--- a/src/rag_ed/loaders/canvas.py
+++ b/src/rag_ed/loaders/canvas.py
@@ -4,6 +4,7 @@ This file contains the CanvasLoader class, which is responsible for loading file
 
 import datetime
 import os
+from pathlib import Path
 
 import langchain_community.document_loaders
 import langchain_core.document_loaders
@@ -16,24 +17,25 @@ class CanvasLoader(langchain_core.document_loaders.BaseLoader):
     The CanvasLoader class is responsible for loading files from a zipped .imscc file which can be exported from Canvas.
     """
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str) -> None:
         """
         Initialize the CanvasLoader with the path to the zipped .imscc file.
 
         Args:
             file_path (str): The path to the zipped .imscc file.
         """
-        if not os.path.exists(file_path):
-            msg = f"Canvas file '{file_path}' does not exist."
+        path = Path(file_path)
+        if not path.is_file():
+            msg = f"Canvas file '{file_path}' does not exist or is not a file."
             raise FileNotFoundError(msg)
-        self.zipped_file_path = file_path
-        self.course = os.path.splitext(os.path.basename(file_path))[0]
+        self.zipped_file_path = str(path)
+        self.course = path.stem
 
-    def load(self):
-        """
-        Load the files from the zipped .imscc file.
+    def load(self) -> list[langchain_core.documents.Document]:
+        """Load the files from the zipped .imscc file.
+
         Returns:
-            list: A list of loaded documents.
+            list[Document]: A list of loaded documents.
         """
         list_of_files_to_load = self._unzip_imscc_file()
         return self._load_files(list_of_files_to_load)

--- a/src/rag_ed/loaders/piazza.py
+++ b/src/rag_ed/loaders/piazza.py
@@ -4,6 +4,7 @@ This file contains the PiazzaLoader class, which is responsible for loading file
 
 import datetime
 import os
+from pathlib import Path
 
 import langchain_community.document_loaders
 import langchain_core.document_loaders
@@ -16,24 +17,25 @@ class PiazzaLoader(langchain_core.document_loaders.BaseLoader):
     The PiazzaLoader class is responsible for loading files from a zipped file which can be exported from Piazza.
     """
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str) -> None:
         """
         Initialize the PiazzaLoader with the path to the zipped file.
 
         Args:
             file_path (str): The path to the zipped file.
         """
-        if not os.path.exists(file_path):
-            msg = f"Piazza file '{file_path}' does not exist."
+        path = Path(file_path)
+        if not path.is_file():
+            msg = f"Piazza file '{file_path}' does not exist or is not a file."
             raise FileNotFoundError(msg)
-        self.zipped_file_path = file_path
-        self.course = os.path.splitext(os.path.basename(file_path))[0]
+        self.zipped_file_path = str(path)
+        self.course = path.stem
 
-    def load(self):
-        """
-        Load the files from the zipped .imscc file.
+    def load(self) -> list[langchain_core.documents.Document]:
+        """Load the files from the zipped Piazza export.
+
         Returns:
-            list: A list of loaded documents.
+            list[Document]: A list of loaded documents.
         """
         list_of_files_to_load = self._unzip_piazza_file()
         return self._load_files(list_of_files_to_load)

--- a/src/rag_ed/retrievers/vectorstore.py
+++ b/src/rag_ed/retrievers/vectorstore.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import langchain.text_splitter
 import langchain.vectorstores
@@ -20,7 +20,7 @@ class VectorStoreRetriever(langchain_core.retrievers.BaseRetriever):
         piazza_path: str,
         in_memory: bool = False,
         k: int = 5,
-    ):
+    ) -> None:
         """Initialize the retriever with the desired vector storage type.
 
         Args:
@@ -30,15 +30,17 @@ class VectorStoreRetriever(langchain_core.retrievers.BaseRetriever):
             k (int): Default number of top documents to retrieve.
         """
 
-        if not os.path.exists(canvas_path):
-            msg = f"Canvas file '{canvas_path}' does not exist."
+        canvas = Path(canvas_path)
+        if not canvas.is_file():
+            msg = f"Canvas file '{canvas_path}' does not exist or is not a file."
             raise FileNotFoundError(msg)
-        if not os.path.exists(piazza_path):
-            msg = f"Piazza file '{piazza_path}' does not exist."
+        piazza = Path(piazza_path)
+        if not piazza.is_file():
+            msg = f"Piazza file '{piazza_path}' does not exist or is not a file."
             raise FileNotFoundError(msg)
 
-        canvas_docs = CanvasLoader(canvas_path).load()
-        piazza_docs = PiazzaLoader(piazza_path).load()
+        canvas_docs = CanvasLoader(str(canvas)).load()
+        piazza_docs = PiazzaLoader(str(piazza)).load()
         documents = canvas_docs + piazza_docs
 
         text_splitter = langchain.text_splitter.RecursiveCharacterTextSplitter(

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import datetime
+
+import pytest
 
 from rag_ed.loaders.canvas import CanvasLoader
 from rag_ed.loaders.piazza import PiazzaLoader
@@ -13,6 +16,15 @@ def test_canvas_loader_returns_document(tmp_path: Path) -> None:
     assert any("minimal Common Cartridge web page" in d.page_content for d in docs)
     for doc in docs:
         assert doc.metadata["course"] == "canvas_sample"
+        datetime.datetime.fromisoformat(doc.metadata["timestamp"])
+
+
+def test_canvas_loader_missing_file() -> None:
+    with pytest.raises(
+        FileNotFoundError,
+        match="Canvas file 'does_not_exist.imscc' does not exist or is not a file.",
+    ):
+        CanvasLoader("does_not_exist.imscc")
 
 
 def test_piazza_loader_returns_document(tmp_path: Path) -> None:
@@ -22,3 +34,12 @@ def test_piazza_loader_returns_document(tmp_path: Path) -> None:
     assert any("Hello from Piazza" in d.page_content for d in docs)
     for doc in docs:
         assert doc.metadata["course"] == "piazza_sample"
+        datetime.datetime.fromisoformat(doc.metadata["timestamp"])
+
+
+def test_piazza_loader_missing_file() -> None:
+    with pytest.raises(
+        FileNotFoundError,
+        match="Piazza file 'does_not_exist.zip' does not exist or is not a file.",
+    ):
+        PiazzaLoader("does_not_exist.zip")

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 import langchain_openai.embeddings
 from rag_ed.loaders.canvas import CanvasLoader
 from rag_ed.loaders.piazza import PiazzaLoader
@@ -45,3 +46,11 @@ def test_vector_store_retriever(monkeypatch, tmp_path: Path) -> None:
     object.__setattr__(retriever, "k", 1)
     results = retriever.retrieve("Hello", k=1)
     assert len(results) == 1
+
+
+def test_vector_store_retriever_missing_files() -> None:
+    with pytest.raises(
+        FileNotFoundError,
+        match="Canvas file 'missing.imscc' does not exist or is not a file.",
+    ):
+        VectorStoreRetriever("missing.imscc", "missing.zip")


### PR DESCRIPTION
## Summary
- validate Canvas, Piazza, and VectorStore inputs with `Path.is_file` and clear `FileNotFoundError`
- type annotate loaders and preserve course/timestamp metadata
- test metadata extraction and error handling for missing files

## Testing
- `ruff check src tests`
- `mypy src tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad137060d08325a0a74b9002017eef