### PR TITLE
feat: pluggable vector stores with persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# rag-ed
+
+Utilities for building retrieval-augmented applications.
+
+## Quickstart
+
+```python
+from rag_ed.retrievers.vectorstore import VectorStoreRetriever
+
+retriever = VectorStoreRetriever(
+    "canvas.imscc",
+    "piazza.zip",
+    vector_store_type="faiss",  # "in_memory" or "chroma"
+    persist_directory="./index",
+)
+docs = retriever.retrieve("machine learning")
+```
+
+`VectorStoreRetriever` accepts custom embedding models via dependency
+injection and can persist FAISS or Chroma indexes to disk for reuse.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ mypy
 pytest
 langchain-core
 langchain-community
+chromadb
 unstructured
 pdfminer.six==20221105
 pi-heif

--- a/src/rag_ed/retrievers/vectorstore.py
+++ b/src/rag_ed/retrievers/vectorstore.py
@@ -1,9 +1,15 @@
+"""Utilities for retrieving documents using vector stores."""
+
+from __future__ import annotations
+
 import os
+from typing import Literal
 
 import langchain.text_splitter
 import langchain.vectorstores
 import langchain_core.callbacks.manager
 import langchain_core.documents
+import langchain_core.embeddings
 import langchain_core.retrievers
 import langchain_openai.embeddings
 
@@ -11,25 +17,52 @@ from rag_ed.loaders.canvas import CanvasLoader
 from rag_ed.loaders.piazza import PiazzaLoader
 
 
+VectorStoreType = Literal["faiss", "in_memory", "chroma"]
+
+
 class VectorStoreRetriever(langchain_core.retrievers.BaseRetriever):
-    """A retriever that uses CanvasLoader and PiazzaLoader to perform vector retrieval."""
+    """Retrieve documents using a configurable vector store.
+
+    Parameters
+    ----------
+    canvas_path : str
+        Path to the Canvas ``.imscc`` file.
+    piazza_path : str
+        Path to the Piazza export ``.zip`` file.
+    vector_store_type : {"faiss", "in_memory", "chroma"}, optional
+        Backend for storing document vectors. Defaults to ``"faiss"``.
+    embeddings : langchain_core.embeddings.Embeddings, optional
+        Embedding model to use. If omitted, :class:`langchain_openai.embeddings.OpenAIEmbeddings`
+        is used.
+    persist_directory : str, optional
+        Directory for persisting and loading vector indexes.
+        Only applies to ``"faiss"`` and ``"chroma"`` stores.
+    k : int, optional
+        Default number of top documents to retrieve.
+
+    Examples
+    --------
+    >>> from rag_ed.retrievers.vectorstore import VectorStoreRetriever
+    >>> retriever = VectorStoreRetriever(
+    ...     "canvas.imscc",
+    ...     "piazza.zip",
+    ...     vector_store_type="in_memory",
+    ... )
+    >>> docs = retriever.retrieve("machine learning")
+    >>> len(docs)
+    5
+    """
 
     def __init__(
         self,
         canvas_path: str,
         piazza_path: str,
-        in_memory: bool = False,
+        *,
+        vector_store_type: VectorStoreType = "faiss",
+        embeddings: langchain_core.embeddings.Embeddings | None = None,
+        persist_directory: str | None = None,
         k: int = 5,
-    ):
-        """Initialize the retriever with the desired vector storage type.
-
-        Args:
-            canvas_path (str): Path to the Canvas .imscc file.
-            piazza_path (str): Path to the Piazza zip file.
-            in_memory (bool): If True, use in-memory vector storage. Otherwise, use FAISS.
-            k (int): Default number of top documents to retrieve.
-        """
-
+    ) -> None:
         if not os.path.exists(canvas_path):
             msg = f"Canvas file '{canvas_path}' does not exist."
             raise FileNotFoundError(msg)
@@ -46,19 +79,42 @@ class VectorStoreRetriever(langchain_core.retrievers.BaseRetriever):
         )
         documents = text_splitter.split_documents(documents)
 
-        embeddings = langchain_openai.embeddings.OpenAIEmbeddings()
+        embeddings = embeddings or langchain_openai.embeddings.OpenAIEmbeddings()
 
-        if in_memory:
-            self.vector_store = (
-                langchain.vectorstores.InMemoryVectorStore.from_documents(
-                    documents, embeddings
-                )
-            )
-        else:
-            self.vector_store = langchain.vectorstores.FAISS.from_documents(
+        if vector_store_type == "in_memory":
+            store = langchain.vectorstores.InMemoryVectorStore.from_documents(
                 documents, embeddings
             )
-        self.k = k
+        elif vector_store_type == "faiss":
+            if persist_directory and os.path.exists(persist_directory):
+                store = langchain.vectorstores.FAISS.load_local(
+                    persist_directory,
+                    embeddings,
+                    allow_dangerous_deserialization=True,
+                )
+            else:
+                store = langchain.vectorstores.FAISS.from_documents(
+                    documents, embeddings
+                )
+                if persist_directory:
+                    store.save_local(persist_directory)
+        elif vector_store_type == "chroma":
+            if persist_directory and os.path.exists(persist_directory):
+                store = langchain.vectorstores.Chroma(
+                    persist_directory=persist_directory,
+                    embedding_function=embeddings,
+                )
+            else:
+                store = langchain.vectorstores.Chroma.from_documents(
+                    documents, embeddings, persist_directory=persist_directory
+                )
+                if persist_directory:
+                    store.persist()
+        else:  # pragma: no cover - safeguarded by type hints
+            msg = f"Unknown vector_store_type: {vector_store_type}"
+            raise ValueError(msg)
+        object.__setattr__(self, "vector_store", store)
+        object.__setattr__(self, "k", k)
 
     def _get_relevant_documents(
         self,
@@ -74,10 +130,10 @@ class VectorStoreRetriever(langchain_core.retrievers.BaseRetriever):
         return self.vector_store.similarity_search(query, k=k or self.k)
 
 
-if __name__ == "__main__":
-    # Example usage
+if __name__ == "__main__":  # pragma: no cover - example usage
     retriever = VectorStoreRetriever(
-        "/Users/work/Downloads/canvas.imscc", "/Users/work/Downloads/piazza.zip"
+        "/Users/work/Downloads/canvas.imscc",
+        "/Users/work/Downloads/piazza.zip",
     )
     results = retriever.retrieve("machine learning", k=3)
     for result in results:

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
+import os
+import langchain_core.documents
 import langchain_openai.embeddings
+import rag_ed.retrievers.vectorstore
 from rag_ed.loaders.canvas import CanvasLoader
 from rag_ed.loaders.piazza import PiazzaLoader
 from rag_ed.retrievers.vectorstore import VectorStoreRetriever
@@ -45,3 +48,198 @@ def test_vector_store_retriever(monkeypatch, tmp_path: Path) -> None:
     object.__setattr__(retriever, "k", 1)
     results = retriever.retrieve("Hello", k=1)
     assert len(results) == 1
+
+
+def test_custom_embeddings_and_inmemory(monkeypatch, tmp_path: Path) -> None:
+    """Ensure custom embeddings and in-memory store are used."""
+
+    class DummyEmbeddings:
+        def embed_documents(self, texts: list[str]) -> list[list[float]]:  # noqa: D401
+            return [[1.0] for _ in texts]
+
+        def embed_query(self, text: str) -> list[float]:  # noqa: D401
+            return [1.0]
+
+    class DummyVectorStore:
+        @classmethod
+        def from_documents(
+            cls, docs: list, embeddings: DummyEmbeddings
+        ) -> "DummyVectorStore":
+            assert embeddings is dummy_embeddings
+            return cls()
+
+        def similarity_search(self, query: str, k: int) -> list:  # noqa: D401
+            return []
+
+    dummy_embeddings = DummyEmbeddings()
+    monkeypatch.setattr(
+        rag_ed.retrievers.vectorstore.langchain.vectorstores,
+        "InMemoryVectorStore",
+        DummyVectorStore,
+        raising=False,
+    )
+
+    class Loader:
+        def __init__(self, _path: str) -> None:  # noqa: D401
+            pass
+
+        def load(self) -> list[langchain_core.documents.Document]:  # noqa: D401
+            return [langchain_core.documents.Document(page_content="x")]
+
+    canvas = tmp_path / "c.imscc"
+    canvas.write_text("x")
+    piazza = tmp_path / "p.zip"
+    piazza.write_text("x")
+    monkeypatch.setattr(rag_ed.retrievers.vectorstore, "CanvasLoader", Loader)
+    monkeypatch.setattr(rag_ed.retrievers.vectorstore, "PiazzaLoader", Loader)
+
+    monkeypatch.setattr(
+        langchain_openai.embeddings,
+        "OpenAIEmbeddings",
+        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("should not call")),
+    )
+
+    VectorStoreRetriever(
+        str(canvas),
+        str(piazza),
+        vector_store_type="in_memory",
+        embeddings=dummy_embeddings,
+    )
+
+
+def test_faiss_persistence(monkeypatch, tmp_path: Path) -> None:
+    """FAISS indexes are saved and loaded from disk."""
+
+    class DummyFAISS:
+        saved: list[str] = []
+        loaded: list[str] = []
+
+        @classmethod
+        def from_documents(
+            cls, docs: list, embeddings: DummyEmbeddings
+        ) -> "DummyFAISS":
+            return cls()
+
+        def save_local(self, directory: str) -> None:  # noqa: D401
+            self.__class__.saved.append(directory)
+            os.makedirs(directory, exist_ok=True)
+
+        @classmethod
+        def load_local(
+            cls,
+            directory: str,
+            embeddings: DummyEmbeddings,
+            allow_dangerous_deserialization: bool,
+        ) -> "DummyFAISS":
+            cls.loaded.append(directory)
+            return cls()
+
+        def similarity_search(self, query: str, k: int) -> list:  # noqa: D401
+            return []
+
+    monkeypatch.setattr(
+        rag_ed.retrievers.vectorstore.langchain.vectorstores, "FAISS", DummyFAISS
+    )
+
+    class Loader:
+        def __init__(self, _path: str) -> None:  # noqa: D401
+            pass
+
+        def load(self) -> list[langchain_core.documents.Document]:  # noqa: D401
+            return [langchain_core.documents.Document(page_content="x")]
+
+    canvas = tmp_path / "c.imscc"
+    canvas.write_text("x")
+    piazza = tmp_path / "p.zip"
+    piazza.write_text("x")
+    persist_dir = tmp_path / "idx"
+    monkeypatch.setattr(rag_ed.retrievers.vectorstore, "CanvasLoader", Loader)
+    monkeypatch.setattr(rag_ed.retrievers.vectorstore, "PiazzaLoader", Loader)
+
+    VectorStoreRetriever(
+        str(canvas),
+        str(piazza),
+        vector_store_type="faiss",
+        embeddings=DummyEmbeddings(),
+        persist_directory=str(persist_dir),
+    )
+    VectorStoreRetriever(
+        str(canvas),
+        str(piazza),
+        vector_store_type="faiss",
+        embeddings=DummyEmbeddings(),
+        persist_directory=str(persist_dir),
+    )
+    assert DummyFAISS.saved == [str(persist_dir)]
+    assert DummyFAISS.loaded == [str(persist_dir)]
+
+
+def test_chroma_persistence(monkeypatch, tmp_path: Path) -> None:
+    """Chroma indexes are saved and reloaded."""
+
+    class DummyChroma:
+        saved: list[str] = []
+        loaded: list[str] = []
+
+        def __init__(
+            self,
+            persist_directory: str | None = None,
+            embedding_function: DummyEmbeddings | None = None,
+        ) -> None:  # noqa: D401
+            if persist_directory:
+                self.__class__.loaded.append(persist_directory)
+
+        @classmethod
+        def from_documents(
+            cls,
+            docs: list,
+            embeddings: DummyEmbeddings,
+            persist_directory: str | None = None,
+        ) -> "DummyChroma":
+            instance = cls(persist_directory, embeddings)
+            if persist_directory:
+                os.makedirs(persist_directory, exist_ok=True)
+                cls.saved.append(persist_directory)
+            return instance
+
+        def persist(self) -> None:  # noqa: D401
+            pass
+
+        def similarity_search(self, query: str, k: int) -> list:  # noqa: D401
+            return []
+
+    monkeypatch.setattr(
+        rag_ed.retrievers.vectorstore.langchain.vectorstores, "Chroma", DummyChroma
+    )
+
+    class Loader:
+        def __init__(self, _path: str) -> None:  # noqa: D401
+            pass
+
+        def load(self) -> list[langchain_core.documents.Document]:  # noqa: D401
+            return [langchain_core.documents.Document(page_content="x")]
+
+    canvas = tmp_path / "c.imscc"
+    canvas.write_text("x")
+    piazza = tmp_path / "p.zip"
+    piazza.write_text("x")
+    persist_dir = tmp_path / "chroma"
+    monkeypatch.setattr(rag_ed.retrievers.vectorstore, "CanvasLoader", Loader)
+    monkeypatch.setattr(rag_ed.retrievers.vectorstore, "PiazzaLoader", Loader)
+
+    VectorStoreRetriever(
+        str(canvas),
+        str(piazza),
+        vector_store_type="chroma",
+        embeddings=DummyEmbeddings(),
+        persist_directory=str(persist_dir),
+    )
+    VectorStoreRetriever(
+        str(canvas),
+        str(piazza),
+        vector_store_type="chroma",
+        embeddings=DummyEmbeddings(),
+        persist_directory=str(persist_dir),
+    )
+    assert DummyChroma.saved == [str(persist_dir)]
+    assert DummyChroma.loaded[-1] == str(persist_dir)


### PR DESCRIPTION
## Summary
- allow choosing FAISS, in-memory, or Chroma vector stores
- support custom embedding injection and on-disk persistence
- document and test new VectorStoreRetriever features

## Testing
- `ruff check src tests`
- `pytest -q`
- `mypy src/rag_ed/retrievers/vectorstore.py tests/test_retriever.py --ignore-missing-imports` *(fails: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68ad13f60a1c83259ba5692d0a869fa2