### PR TITLE
chore: format test_retriever with black

### DIFF
--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -244,6 +244,7 @@ def test_chroma_persistence(monkeypatch, tmp_path: Path) -> None:
     assert DummyChroma.saved == [str(persist_dir)]
     assert DummyChroma.loaded[-1] == str(persist_dir)
 
+
 def test_vector_store_retriever_missing_files() -> None:
     with pytest.raises(
         FileNotFoundError,


### PR DESCRIPTION
## Summary
- format `tests/test_retriever.py` using black

## Testing
- `black --check .`
- `ruff check .`
- `mypy .` *(fails: VectorStoreRetriever attributes and type mismatches)*
- `pytest` *(fails: test_vector_store_retriever_missing_files regex mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68ad18c4f31083258d0347ca679f62b1