### PR TITLE
Add Canvas API loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+
+### Added
+- `CanvasAPILoader` for retrieving assignments, quizzes, and announcements from the Canvas API.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,13 @@ docs = retriever.retrieve("machine learning")
 `VectorStoreRetriever` accepts custom embedding models via dependency
 injection and can persist FAISS or Chroma indexes to disk for reuse.
 
+## Config
+
+The Canvas API loader authenticates using a bearer token. Set the
+``CANVAS_API_TOKEN`` environment variable before using
+``CanvasAPILoader``:
+
+```bash
+export CANVAS_API_TOKEN="<your-canvas-token>"
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,16 +2,18 @@ black
 ruff
 mypy
 pytest
-langchain-core
-langchain-community
+langchain - core
+langchain - community
 chromadb
 unstructured
-pdfminer.six==20221105
-pi-heif
-unstructured-inference
+pdfminer.six == 20221105
+pi - heif
+unstructured - inference
 tqdm
 pdf2image
-unstructured-pytesseract
+unstructured - pytesseract
 jq
 smolagents
-langchain-openai
+langchain - openai
+requests
+responses

--- a/src/rag_ed/__init__.py
+++ b/src/rag_ed/__init__.py
@@ -4,7 +4,13 @@ This module provides a unified interface for various data loaders used for educa
 
 # Re-export the loaders for easier access
 from rag_ed.loaders.canvas import CanvasLoader
+from rag_ed.loaders.canvas_api import CanvasAPILoader
 from rag_ed.loaders.piazza import PiazzaLoader
 from rag_ed.retrievers.vectorstore import VectorStoreRetriever
 
-__all__ = ["CanvasLoader", "PiazzaLoader", "VectorStoreRetriever"]
+__all__ = [
+    "CanvasLoader",
+    "CanvasAPILoader",
+    "PiazzaLoader",
+    "VectorStoreRetriever",
+]

--- a/src/rag_ed/loaders/canvas_api.py
+++ b/src/rag_ed/loaders/canvas_api.py
@@ -1,0 +1,133 @@
+"""Canvas API loader."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+import requests
+from langchain_core.document_loaders import BaseLoader
+from langchain_core.documents import Document
+
+
+class CanvasAPILoader(BaseLoader):
+    """Load Canvas course data via the Canvas REST API.
+
+    The loader retrieves assignments, quizzes, and announcements for a course
+    using a bearer token for authentication.
+    """
+
+    def __init__(
+        self, base_url: str, course_id: int, token: Optional[str] = None
+    ) -> None:
+        """Initialize the loader.
+
+        Args:
+            base_url: Base URL of the Canvas instance, e.g. ``"https://canvas.instructure.com"``.
+            course_id: The Canvas course identifier.
+            token: API token. Falls back to ``CANVAS_API_TOKEN`` environment variable.
+        """
+        self.base_url = base_url.rstrip("/")
+        self.course_id = course_id
+        self.token = token or os.environ["CANVAS_API_TOKEN"]
+
+    def load(self) -> List[Document]:  # type: ignore[override]
+        """Retrieve assignments, quizzes, and announcements."""
+        documents: List[Document] = []
+        documents.extend(
+            self._load_endpoint(
+                f"/api/v1/courses/{self.course_id}/assignments",
+                self._assignment_to_doc,
+            )
+        )
+        documents.extend(
+            self._load_endpoint(
+                f"/api/v1/courses/{self.course_id}/quizzes",
+                self._quiz_to_doc,
+            )
+        )
+        documents.extend(
+            self._load_endpoint(
+                "/api/v1/announcements",
+                self._announcement_to_doc,
+                params={"context_codes[]": f"course_{self.course_id}"},
+            )
+        )
+        return documents
+
+    def _load_endpoint(
+        self,
+        endpoint: str,
+        converter: Callable[[Dict[str, Any]], Document],
+        params: Optional[Dict[str, Any]] = None,
+    ) -> List[Document]:
+        url = f"{self.base_url}{endpoint}"
+        documents: List[Document] = []
+        while url:
+            response = self._get(url, params=params)
+            data = response.json()
+            for item in data:
+                documents.append(converter(item))
+            url = response.links.get("next", {}).get("url")
+            params = None
+        return documents
+
+    def _get(
+        self, url: str, params: Optional[Dict[str, Any]] = None
+    ) -> requests.Response:
+        headers = {"Authorization": f"Bearer {self.token}"}
+        while True:
+            response = requests.get(url, headers=headers, params=params, timeout=30)
+            if response.status_code == 429:
+                self._respect_rate_limits(response)
+                continue
+            self._respect_rate_limits(response)
+            response.raise_for_status()
+            return response
+
+    @staticmethod
+    def _respect_rate_limits(response: requests.Response) -> None:
+        remaining = response.headers.get("X-Rate-Limit-Remaining")
+        reset = response.headers.get("X-Rate-Limit-Reset")
+        retry = response.headers.get("Retry-After")
+        delay = 0
+        if retry and retry.isdigit():
+            delay = int(retry)
+        elif remaining == "0" and reset and reset.isdigit():
+            delay = int(reset)
+        if delay > 0:
+            time.sleep(delay)
+
+    def _assignment_to_doc(self, item: Dict[str, Any]) -> Document:
+        content = f"{item.get('name', '')}\n\n{item.get('description', '')}"
+        metadata = self._build_metadata(item, "assignment", item.get("html_url"))
+        return Document(page_content=content, metadata=metadata)
+
+    def _quiz_to_doc(self, item: Dict[str, Any]) -> Document:
+        content = f"{item.get('title', '')}\n\n{item.get('description', '')}"
+        metadata = self._build_metadata(item, "quiz", item.get("html_url"))
+        return Document(page_content=content, metadata=metadata)
+
+    def _announcement_to_doc(self, item: Dict[str, Any]) -> Document:
+        content = f"{item.get('title', '')}\n\n{item.get('message', '')}"
+        metadata = self._build_metadata(item, "announcement", item.get("html_url"))
+        return Document(page_content=content, metadata=metadata)
+
+    def _build_metadata(
+        self, item: Dict[str, Any], resource_type: str, source: Optional[str]
+    ) -> Dict[str, Any]:
+        metadata: Dict[str, Any] = {
+            "course_id": self.course_id,
+            "resource_type": resource_type,
+        }
+        if source:
+            metadata["source"] = source
+        if "id" in item:
+            metadata["id"] = item["id"]
+        timestamp = (
+            item.get("updated_at") or item.get("created_at") or item.get("posted_at")
+        )
+        if timestamp:
+            metadata["timestamp"] = timestamp
+        return metadata

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 import datetime
+import time
 
 import pytest
 
 from rag_ed.loaders.canvas import CanvasLoader
+from rag_ed.loaders.canvas_api import CanvasAPILoader
 from rag_ed.loaders.piazza import PiazzaLoader
 from tests.imscc_utils import generate_imscc
 from tests.piazza_utils import generate_piazza_export
@@ -25,6 +27,130 @@ def test_canvas_loader_missing_file() -> None:
         match="Canvas file 'does_not_exist.imscc' does not exist or is not a file.",
     ):
         CanvasLoader("does_not_exist.imscc")
+
+
+def test_canvas_api_loader_fetches_documents() -> None:
+    base_url = "https://canvas.example"
+    course_id = 123
+    token = "tok"
+
+    import responses
+
+    with responses.RequestsMock() as rsps:
+        # assignments pagination
+        first_assign_url = f"{base_url}/api/v1/courses/{course_id}/assignments"
+        second_assign_url = f"{first_assign_url}?page=2"
+        rsps.add(
+            "GET",
+            first_assign_url,
+            json=[
+                {
+                    "id": 1,
+                    "name": "A1",
+                    "description": "desc1",
+                    "html_url": "a1",
+                    "updated_at": "2023-01-01T00:00:00Z",
+                }
+            ],
+            adding_headers={"Link": f'<{second_assign_url}>; rel="next"'},
+        )
+        rsps.add(
+            "GET",
+            second_assign_url,
+            json=[
+                {
+                    "id": 2,
+                    "name": "A2",
+                    "description": "desc2",
+                    "html_url": "a2",
+                    "updated_at": "2023-01-02T00:00:00Z",
+                }
+            ],
+        )
+        # quizzes
+        rsps.add(
+            "GET",
+            f"{base_url}/api/v1/courses/{course_id}/quizzes",
+            json=[
+                {
+                    "id": 10,
+                    "title": "Q1",
+                    "description": "qdesc",
+                    "html_url": "q1",
+                    "updated_at": "2023-01-03T00:00:00Z",
+                }
+            ],
+        )
+        # announcements
+        rsps.add(
+            "GET",
+            f"{base_url}/api/v1/announcements",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"context_codes[]": f"course_{course_id}"}
+                )
+            ],
+            json=[
+                {
+                    "id": 100,
+                    "title": "Ann",
+                    "message": "announcement",
+                    "html_url": "ann",
+                    "posted_at": "2023-01-04T00:00:00Z",
+                }
+            ],
+        )
+
+        loader = CanvasAPILoader(base_url, course_id, token)
+        docs = loader.load()
+
+    assert len(docs) == 4
+    types = {d.metadata["resource_type"] for d in docs}
+    assert types == {"assignment", "quiz", "announcement"}
+
+
+def test_canvas_api_loader_respects_rate_limits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base_url = "https://canvas.example"
+    course_id = 1
+    token = "tok"
+
+    import responses
+
+    called: list[int] = []
+    monkeypatch.setattr(time, "sleep", lambda s: called.append(s))
+
+    with responses.RequestsMock() as rsps:
+        rsps.add(
+            "GET",
+            f"{base_url}/api/v1/courses/{course_id}/assignments",
+            json=[],
+            adding_headers={
+                "X-Rate-Limit-Remaining": "0",
+                "X-Rate-Limit-Reset": "1",
+            },
+        )
+        rsps.add(
+            "GET",
+            f"{base_url}/api/v1/courses/{course_id}/quizzes",
+            json=[],
+        )
+        rsps.add(
+            "GET",
+            f"{base_url}/api/v1/announcements",
+            match=[
+                responses.matchers.query_param_matcher(
+                    {"context_codes[]": f"course_{course_id}"}
+                )
+            ],
+            json=[],
+        )
+
+        loader = CanvasAPILoader(base_url, course_id, token)
+        loader.load()
+
+    assert called == [1]
 
 
 def test_piazza_loader_returns_document(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add CanvasAPILoader for assignments, quizzes, and announcements via Canvas API
- document Canvas API token env var and changelog entry
- test CanvasAPILoader pagination and rate limit handling

## Testing
- `black src/rag_ed/loaders/canvas_api.py tests/test_loaders.py src/rag_ed/__init__.py requirements.txt`
- `ruff check .`
- `pytest tests/test_loaders.py::test_canvas_api_loader_fetches_documents -q`
- `pytest tests/test_loaders.py::test_canvas_api_loader_respects_rate_limits -q`
- ⚠️ `mypy .` *(hangs without output)*

------
https://chatgpt.com/codex/tasks/task_e_68ad17b463f48325be417e3a59f6c1f5