### PR TITLE
feat: add self-querying agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,17 @@ docs = retriever.retrieve("machine learning")
 `VectorStoreRetriever` accepts custom embedding models via dependency
 injection and can persist FAISS or Chroma indexes to disk for reuse.
 
+### Self-querying agent
+
+Set the ``CANVAS_PATH`` and ``PIAZZA_PATH`` environment variables to point to
+course exports, then query the agent:
+
+```python
+import os
+from rag_ed.agents import self_querying
+
+os.environ["CANVAS_PATH"] = "canvas.imscc"
+os.environ["PIAZZA_PATH"] = "piazza.zip"
+print(self_querying.run_agent("overview of week one and then week two"))
+```
+

--- a/src/rag_ed/agents/self_querying.py
+++ b/src/rag_ed/agents/self_querying.py
@@ -1,0 +1,77 @@
+"""Self-querying agent for iterative retrieval.
+
+The agent decomposes a user's question into simpler sub-queries and retrieves
+relevant context for each step using :class:`~rag_ed.retrievers.vectorstore.VectorStoreRetriever`.
+All configuration is provided via environment variables so no file paths are
+hard coded in the source.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import List
+
+import langchain_core.documents
+
+from rag_ed.retrievers.vectorstore import VectorStoreRetriever
+
+_RETRIEVER: VectorStoreRetriever | None = None
+
+
+def _split_query(query: str) -> list[str]:
+    """Split ``query`` into individual sub-queries.
+
+    Parameters
+    ----------
+    query:
+        The user's full question.
+
+    Returns
+    -------
+    list[str]
+        A list of simplified sub-queries.
+    """
+
+    parts = re.split(r"\b(?:and|then)\b|[?\n]", query, flags=re.IGNORECASE)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _get_retriever() -> VectorStoreRetriever:
+    """Lazily construct the :class:`VectorStoreRetriever`.
+
+    The retriever is cached at module level. ``CANVAS_PATH`` and ``PIAZZA_PATH``
+    environment variables must be set to point to the course exports.
+    """
+
+    global _RETRIEVER
+    if _RETRIEVER is None:
+        canvas_path = os.getenv("CANVAS_PATH")
+        piazza_path = os.getenv("PIAZZA_PATH")
+        if not canvas_path or not piazza_path:
+            msg = "Environment variables CANVAS_PATH and PIAZZA_PATH must be set"
+            raise RuntimeError(msg)
+        _RETRIEVER = VectorStoreRetriever(
+            canvas_path, piazza_path, vector_store_type="in_memory"
+        )
+    return _RETRIEVER
+
+
+def run_agent(query: str) -> str:
+    """Answer ``query`` using iterative retrieval.
+
+    Examples
+    --------
+    >>> os.environ["CANVAS_PATH"] = "canvas.imscc"
+    >>> os.environ["PIAZZA_PATH"] = "piazza.zip"
+    >>> run_agent("topic one and then topic two")
+    'Sub-query: topic one\n...'
+    """
+
+    retriever = _get_retriever()
+    responses: List[str] = []
+    for sub_query in _split_query(query):
+        docs: list[langchain_core.documents.Document] = retriever.retrieve(sub_query, 5)
+        docs_text = "\n".join(doc.page_content for doc in docs)
+        responses.append(f"Sub-query: {sub_query}\n{docs_text}")
+    return "\n\n".join(responses)

--- a/src/rag_ed/agents/vanilla_rag.py
+++ b/src/rag_ed/agents/vanilla_rag.py
@@ -1,3 +1,10 @@
+"""Simple one-step retrieval agent.
+
+The module provides a thin wrapper around :class:`~rag_ed.retrievers.vectorstore`
+to perform a single retrieval and answer a query. File paths are supplied by the
+caller; no paths are hard coded within the module.
+"""
+
 import argparse
 
 from langchain.chains import RetrievalQA
@@ -6,36 +13,45 @@ from langchain.llms import OpenAI
 from rag_ed.retrievers.vectorstore import VectorStoreRetriever
 
 
-def one_step_retrieval(query: str) -> str:
+def one_step_retrieval(query: str, *, canvas_path: str, piazza_path: str) -> str:
+    """Answer ``query`` using a single retrieval step.
+
+    Parameters
+    ----------
+    query:
+        User question to answer.
+    canvas_path:
+        Path to a Canvas ``.imscc`` export.
+    piazza_path:
+        Path to a Piazza ``.zip`` export.
+
+    Returns
+    -------
+    str
+        The answer returned by the language model.
     """
-    Perform one-step retrieval using the specified query.
-    Args:
-        query (str): The query string.
-    Returns:
-        str: The answer to the query.
-    """
-    # Initialize the retriever with sample file paths
+
     retriever = VectorStoreRetriever(
-        canvas_path="/Users/work/Downloads/canvas.imscc",
-        piazza_path="/Users/work/Downloads/piazza.zip",
-        in_memory=True,
+        canvas_path=canvas_path, piazza_path=piazza_path, vector_store_type="in_memory"
     )
-    # Create a RetrievalQA chain using the retriever's vector store
     qa = RetrievalQA.from_chain_type(
         llm=OpenAI(temperature=0.7, model_name="gpt-4o-mini"),
         chain_type="stuff",
         retriever=retriever.vector_store,
     )
-    answer = qa.run(query)
-    return answer
+    return qa.run(query)
 
 
 def main() -> None:
     """CLI entry point for one-step retrieval."""
     parser = argparse.ArgumentParser(description="Run one-step retrieval")
     parser.add_argument("query", help="Query string")
+    parser.add_argument("--canvas", required=True, help="Path to Canvas .imscc file")
+    parser.add_argument("--piazza", required=True, help="Path to Piazza export .zip")
     args = parser.parse_args()
-    print(one_step_retrieval(args.query))
+    print(
+        one_step_retrieval(args.query, canvas_path=args.canvas, piazza_path=args.piazza)
+    )
 
 
 if __name__ == "__main__":

--- a/src/rag_ed/retrievers/vectorstore.py
+++ b/src/rag_ed/retrievers/vectorstore.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Literal
+from typing import Any, Literal
 from pathlib import Path
 
 import langchain.text_splitter
@@ -54,6 +54,9 @@ class VectorStoreRetriever(langchain_core.retrievers.BaseRetriever):
     5
     """
 
+    vector_store: Any
+    k: int
+
     def __init__(
         self,
         canvas_path: str,
@@ -72,9 +75,6 @@ class VectorStoreRetriever(langchain_core.retrievers.BaseRetriever):
             in_memory (bool): If True, use in-memory vector storage. Otherwise, use FAISS.
             k (int): Default number of top documents to retrieve.
         """
-        if not os.path.exists(canvas_path):
-            msg = f"Canvas file '{canvas_path}' does not exist."
-            raise FileNotFoundError(msg)
         canvas = Path(canvas_path)
         if not canvas.is_file():
             msg = f"Canvas file '{canvas_path}' does not exist or is not a file."
@@ -145,10 +145,7 @@ class VectorStoreRetriever(langchain_core.retrievers.BaseRetriever):
 
 
 if __name__ == "__main__":  # pragma: no cover - example usage
-    retriever = VectorStoreRetriever(
-        "/Users/work/Downloads/canvas.imscc",
-        "/Users/work/Downloads/piazza.zip",
-    )
+    retriever = VectorStoreRetriever("canvas.imscc", "piazza.zip")
     results = retriever.retrieve("machine learning", k=3)
     for result in results:
         print(result)


### PR DESCRIPTION
## Summary
- implement self-querying agent that splits complex queries and retrieves results iteratively
- parameterize agents to remove hard-coded paths
- add tests for multi-step question handling

## Testing
- `ruff check src/rag_ed/retrievers/vectorstore.py src/rag_ed/agents/vanilla_rag.py src/rag_ed/agents/self_querying.py tests/test_agents.py`
- `mypy src/rag_ed/agents/vanilla_rag.py src/rag_ed/agents/self_querying.py src/rag_ed/retrievers/vectorstore.py tests/test_agents.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad17b717f8832599122dfba4670c9e