### PR TITLE
feat: extend canvas loader file support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ unstructured-pytesseract
 jq
 smolagents
 langchain-openai
+python-pptx==1.0.2

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -244,9 +244,10 @@ def test_chroma_persistence(monkeypatch, tmp_path: Path) -> None:
     assert DummyChroma.saved == [str(persist_dir)]
     assert DummyChroma.loaded[-1] == str(persist_dir)
 
+
 def test_vector_store_retriever_missing_files() -> None:
     with pytest.raises(
         FileNotFoundError,
-        match="Canvas file 'missing.imscc' does not exist or is not a file.",
+        match="Canvas file 'missing.imscc' does not exist.",
     ):
         VectorStoreRetriever("missing.imscc", "missing.zip")


### PR DESCRIPTION
## Summary
- support common document formats in Canvas exports (markdown, office, csv/tsv, etc.)
- add pptx regression test and adjust missing Canvas file expectation
- pin python-pptx dependency for PPTX handling

## Testing
- `pip install -r requirements.txt`
- `black .`
- `ruff check .`
- `mypy .` *(fails: VectorStoreRetriever attribute errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad176ed0f08325b37ce43914a5b7d7