### PR TITLE
Add pass-through embeddings and retrieval tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,5 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
+        additional_dependencies:
+          - types-requests

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 ```bash
 pip install rag-ed
 vanilla-rag --canvas path/to/export.imscc --piazza path/to/export.zip "What is due next week?"
+# run offline and return retrieved documents
+vanilla-rag --pass-through --canvas path/to/export.imscc --piazza path/to/export.zip "Piazza"
 ```
 
 The CLI expects an OpenAI API key in the `OPENAI_API_KEY` environment variable.
@@ -26,6 +28,18 @@ answer = one_step_retrieval(
     piazza_path="piazza.zip",
 )
 print(answer)
+
+# offline pass-through mode
+from rag_ed.embeddings import PassThroughEmbeddings
+
+docs = one_step_retrieval(
+    "Piazza",
+    canvas_path="course.imscc",
+    piazza_path="piazza.zip",
+    pass_through=True,
+    embeddings=PassThroughEmbeddings(),
+)
+print(docs)
 ```
 
 ```python

--- a/src/rag_ed/agents/vanilla_rag.py
+++ b/src/rag_ed/agents/vanilla_rag.py
@@ -7,13 +7,22 @@ caller; no paths are hard coded within the module.
 
 import argparse
 
+import langchain_core.embeddings
 from langchain.chains import RetrievalQA
 from langchain.llms import OpenAI
 
+from rag_ed.embeddings import PassThroughEmbeddings
 from rag_ed.retrievers.vectorstore import VectorStoreRetriever
 
 
-def one_step_retrieval(query: str, *, canvas_path: str, piazza_path: str) -> str:
+def one_step_retrieval(
+    query: str,
+    *,
+    canvas_path: str,
+    piazza_path: str,
+    pass_through: bool = False,
+    embeddings: langchain_core.embeddings.Embeddings | None = None,
+) -> str:
     """Answer ``query`` using a single retrieval step.
 
     Parameters
@@ -24,16 +33,29 @@ def one_step_retrieval(query: str, *, canvas_path: str, piazza_path: str) -> str
         Path to a Canvas ``.imscc`` export.
     piazza_path:
         Path to a Piazza ``.zip`` export.
+    pass_through:
+        If ``True``, return retrieved documents directly instead of calling an
+        LLM.
+    embeddings:
+        Optional embedding model. Defaults to
+        :class:`langchain_openai.embeddings.OpenAIEmbeddings`.
 
     Returns
     -------
     str
-        The answer returned by the language model.
+        The answer returned by the language model or concatenated documents
+        when ``pass_through`` is ``True``.
     """
 
     retriever = VectorStoreRetriever(
-        canvas_path=canvas_path, piazza_path=piazza_path, vector_store_type="in_memory"
+        canvas_path=canvas_path,
+        piazza_path=piazza_path,
+        vector_store_type="in_memory",
+        embeddings=embeddings,
     )
+    if pass_through:
+        docs = retriever.retrieve(query)
+        return "\n".join(doc.page_content for doc in docs)
     qa = RetrievalQA.from_chain_type(
         llm=OpenAI(temperature=0.7, model_name="gpt-4o-mini"),
         chain_type="stuff",
@@ -48,9 +70,22 @@ def main() -> None:
     parser.add_argument("query", help="Query string")
     parser.add_argument("--canvas", required=True, help="Path to Canvas .imscc file")
     parser.add_argument("--piazza", required=True, help="Path to Piazza export .zip")
+    parser.add_argument(
+        "--pass-through",
+        action="store_true",
+        help="Return retrieved documents without calling the LLM.",
+    )
     args = parser.parse_args()
+
+    embeddings = PassThroughEmbeddings() if args.pass_through else None
     print(
-        one_step_retrieval(args.query, canvas_path=args.canvas, piazza_path=args.piazza)
+        one_step_retrieval(
+            args.query,
+            canvas_path=args.canvas,
+            piazza_path=args.piazza,
+            pass_through=args.pass_through,
+            embeddings=embeddings,
+        )
     )
 
 

--- a/src/rag_ed/embeddings/__init__.py
+++ b/src/rag_ed/embeddings/__init__.py
@@ -1,0 +1,5 @@
+"""Embedding utilities."""
+
+from .pass_through import PassThroughEmbeddings
+
+__all__ = ["PassThroughEmbeddings"]

--- a/src/rag_ed/embeddings/pass_through.py
+++ b/src/rag_ed/embeddings/pass_through.py
@@ -1,0 +1,41 @@
+"""Deterministic embeddings for testing.
+
+The :class:`PassThroughEmbeddings` class implements a lightweight bag-of-words
+embedding that hashes tokens into a fixed-size vector. This avoids any network
+calls to external language model APIs and is suitable for offline tests.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from langchain_core.embeddings import Embeddings
+
+
+class PassThroughEmbeddings(Embeddings):
+    """Simple hash-based embeddings that require no external service."""
+
+    def __init__(self, dimension: int = 128) -> None:
+        """Create a new :class:`PassThroughEmbeddings` instance.
+
+        Parameters
+        ----------
+        dimension:
+            Length of the generated embedding vectors.
+        """
+        self._dim = dimension
+
+    def _embed(self, text: str) -> List[float]:
+        vec = [0.0] * self._dim
+        for token in text.lower().split():
+            idx = hash(token) % self._dim
+            vec[idx] += 1.0
+        return vec
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        """Embed a list of documents."""
+        return [self._embed(t) for t in texts]
+
+    def embed_query(self, text: str) -> List[float]:
+        """Embed a single query string."""
+        return self._embed(text)


### PR DESCRIPTION
## Summary
- add PassThroughEmbeddings for offline, deterministic vectorization
- extend vanilla_rag with pass-through option and CLI flag
- test embedding and retrieval on mocked Canvas/Piazza exports

## Testing
- `pre-commit run --files tests/test_retriever.py tests/test_agents.py src/rag_ed/embeddings/__init__.py src/rag_ed/embeddings/pass_through.py src/rag_ed/agents/vanilla_rag.py README.md .pre-commit-config.yaml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bad9e949208325964a6140c8370542